### PR TITLE
Simplify dialog

### DIFF
--- a/app/_hooks/forms/useEditAssignmentForm.tsx
+++ b/app/_hooks/forms/useEditAssignmentForm.tsx
@@ -29,6 +29,9 @@ export function useEditAssignmentForm(
 
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["assignments"] });
+      queryClient.invalidateQueries({
+        queryKey: ["assignment", assignment.id],
+      });
       form.reset();
       if (onSuccessCallback) onSuccessCallback();
     },

--- a/app/_hooks/forms/useEditExamForm.tsx
+++ b/app/_hooks/forms/useEditExamForm.tsx
@@ -49,8 +49,10 @@ export function useEditExamForm(
     mutationFn: updateExam,
 
     onSuccess: () => {
-      ``;
       queryClient.invalidateQueries({ queryKey: ["exams"] });
+      queryClient.invalidateQueries({
+        queryKey: ["exam", examID],
+      });
       form.reset();
       if (onSuccessCallback) onSuccessCallback();
     },

--- a/app/_hooks/forms/useEditExamForm.tsx
+++ b/app/_hooks/forms/useEditExamForm.tsx
@@ -49,6 +49,7 @@ export function useEditExamForm(
     mutationFn: updateExam,
 
     onSuccess: () => {
+      ``;
       queryClient.invalidateQueries({ queryKey: ["exams"] });
       form.reset();
       if (onSuccessCallback) onSuccessCallback();

--- a/components/AssignmentsList/Assignment.tsx
+++ b/components/AssignmentsList/Assignment.tsx
@@ -31,10 +31,8 @@ interface AssignmentProps {
  *
  */
 const Assignment: React.FC<AssignmentProps> = ({ assignment }) => {
-  const [openEditDialog, setOpenEditDialog] = useState(false);
   const [openViewDialog, setOpenViewDialog] = useState(false);
 
-  const path = usePathname();
   const queryClient = useQueryClient();
 
   const deleteAssignmentMutation = useMutation({
@@ -90,7 +88,7 @@ const Assignment: React.FC<AssignmentProps> = ({ assignment }) => {
             />
           </Dialog>
         </ContextMenuTrigger>
-        <ContextMenuContent hidden={openEditDialog}>
+        <ContextMenuContent>
           <ContextMenuItem onSelect={handleDeleteAssignment}>
             Complete
           </ContextMenuItem>

--- a/components/AssignmentsList/Assignment.tsx
+++ b/components/AssignmentsList/Assignment.tsx
@@ -33,7 +33,6 @@ interface AssignmentProps {
 const Assignment: React.FC<AssignmentProps> = ({ assignment }) => {
   const [openEditDialog, setOpenEditDialog] = useState(false);
   const [openViewDialog, setOpenViewDialog] = useState(false);
-  const [menuKey, setMenuKey] = useState(0);
   const path = usePathname();
   const queryClient = useQueryClient();
 
@@ -48,45 +47,11 @@ const Assignment: React.FC<AssignmentProps> = ({ assignment }) => {
     deleteAssignmentMutation.mutate(assignment.id as unknown as number);
   }
 
-  function handleEditDialogOpenChange(open: boolean, swapTo?: string) {
-    setOpenEditDialog(open);
-    if (swapTo === "view") {
-      setOpenViewDialog(true);
-    }
-    if (open == false) {
-      setMenuKey((prev) => prev + 1);
-    }
-  }
-
-  function handleViewDialogOpenChange(open: boolean, swapTo?: string) {
-    setOpenViewDialog(open);
-    if (swapTo === "edit") {
-      setOpenEditDialog(true);
-    }
-    if (open == false) {
-      setMenuKey((prev) => prev + 1);
-    }
-  }
-
-  function swapDialog(to: "edit" | "view") {
-    setOpenViewDialog(false);
-    if (to === "edit") {
-      setOpenEditDialog(true);
-    } else {
-      setOpenEditDialog(true);
-    }
-  }
-
-  function handleDeleteAssignmentFromDialog() {
-    setOpenViewDialog(false);
-    handleDeleteAssignment();
-  }
-
   return (
     <>
       <hr className="h-px w-full bg-gray-400 border-0" />
 
-      <ContextMenu key={menuKey}>
+      <ContextMenu>
         <ContextMenuTrigger>
           <div className="flex flex-row w-full hover:bg-gray-100 dark:hover:bg-zinc-800">
             <div
@@ -117,39 +82,6 @@ const Assignment: React.FC<AssignmentProps> = ({ assignment }) => {
           <ContextMenuItem onSelect={handleDeleteAssignment}>
             Complete
           </ContextMenuItem>
-
-          {/* Edit Button */}
-          <Dialog
-            open={openEditDialog}
-            onOpenChange={handleEditDialogOpenChange}
-          >
-            <DialogTrigger asChild>
-              <ContextMenuItem onSelect={(e) => e.preventDefault()}>
-                Edit
-              </ContextMenuItem>
-            </DialogTrigger>
-            <EditAssignmentDialog
-              assignment={assignment}
-              setOpen={setOpenEditDialog}
-              handleDialogOpenChangeFn={handleEditDialogOpenChange}
-            />
-          </Dialog>
-          {/* View Button */}
-          <Dialog
-            open={openViewDialog}
-            onOpenChange={handleViewDialogOpenChange}
-          >
-            <DialogTrigger asChild>
-              <ContextMenuItem onSelect={(e) => e.preventDefault()}>
-                View
-              </ContextMenuItem>
-            </DialogTrigger>
-            <ViewAssignmentDialog
-              assignment={assignment}
-              swapDialogFn={() => swapDialog("edit")}
-              handleDeleteAssignment={handleDeleteAssignmentFromDialog}
-            />
-          </Dialog>
         </ContextMenuContent>
       </ContextMenu>
     </>

--- a/components/AssignmentsList/Assignment.tsx
+++ b/components/AssignmentsList/Assignment.tsx
@@ -33,6 +33,7 @@ interface AssignmentProps {
 const Assignment: React.FC<AssignmentProps> = ({ assignment }) => {
   const [openEditDialog, setOpenEditDialog] = useState(false);
   const [openViewDialog, setOpenViewDialog] = useState(false);
+
   const path = usePathname();
   const queryClient = useQueryClient();
 
@@ -44,7 +45,7 @@ const Assignment: React.FC<AssignmentProps> = ({ assignment }) => {
   });
 
   function handleDeleteAssignment() {
-    deleteAssignmentMutation.mutate(assignment.id as unknown as number);
+    deleteAssignmentMutation.mutate(assignment.id);
   }
 
   return (
@@ -53,30 +54,41 @@ const Assignment: React.FC<AssignmentProps> = ({ assignment }) => {
 
       <ContextMenu>
         <ContextMenuTrigger>
-          <div className="flex flex-row w-full hover:bg-gray-100 dark:hover:bg-zinc-800">
-            <div
-              className="w-1"
-              style={{ backgroundColor: assignment.course.color }}
-            ></div>
-            <div className="p-2 flex justify-between w-full">
-              <div>
-                <h4 className="text-md font-medium text-off-black">
-                  {assignment.title}
-                </h4>
-                <h5 className="text-sm text-gray-500 dark:text-gray-400">
-                  {assignment.course.title}
-                </h5>
+          <Dialog
+            open={openViewDialog}
+            onOpenChange={(open) => setOpenViewDialog(open)}
+          >
+            <DialogTrigger asChild>
+              <div className="flex flex-row w-full hover:bg-gray-100 dark:hover:bg-zinc-800">
+                <div
+                  className="w-1"
+                  style={{ backgroundColor: assignment.course.color }}
+                ></div>
+                <div className="p-2 flex justify-between w-full">
+                  <div>
+                    <h4 className="text-md font-medium text-off-black">
+                      {assignment.title}
+                    </h4>
+                    <h5 className="text-sm text-gray-500 dark:text-gray-400">
+                      {assignment.course.title}
+                    </h5>
+                  </div>
+                  <div>
+                    <h5 className="text-sm text-off-black text-nowrap">
+                      {format(
+                        utcToZonedTime(assignment.dueDate, "Etc/UTC"),
+                        "MMM d",
+                      )}
+                    </h5>
+                  </div>
+                </div>
               </div>
-              <div>
-                <h5 className="text-sm text-off-black text-nowrap">
-                  {format(
-                    utcToZonedTime(assignment.dueDate, "Etc/UTC"),
-                    "MMM d",
-                  )}
-                </h5>
-              </div>
-            </div>
-          </div>
+            </DialogTrigger>
+            <ViewAssignmentDialog
+              assignmentID={assignment.id}
+              closeDialog={() => setOpenViewDialog(false)}
+            />
+          </Dialog>
         </ContextMenuTrigger>
         <ContextMenuContent hidden={openEditDialog}>
           <ContextMenuItem onSelect={handleDeleteAssignment}>

--- a/components/ExamsList/Exam.tsx
+++ b/components/ExamsList/Exam.tsx
@@ -23,9 +23,7 @@ interface ExamProps {
 const Exam: React.FC<ExamProps> = ({ exam }) => {
   const queryClient = useQueryClient();
 
-  const [openEditDialog, setOpenEditDialog] = useState(false);
   const [openViewDialog, setOpenViewDialog] = useState(false);
-  const [menuKey, setMenuKey] = useState(0);
 
   const deleteExamMutation = useMutation({
     mutationFn: deleteExam,
@@ -37,99 +35,51 @@ const Exam: React.FC<ExamProps> = ({ exam }) => {
   function handleDeleteExam() {
     deleteExamMutation.mutate(exam.id as unknown as number);
   }
-
-  function handleDialogOpenChange(open: boolean) {
-    setOpenEditDialog(open);
-
-    if (open == false) {
-      setMenuKey((prev) => prev + 1);
-    }
-  }
-
-  function swapDialog(to: "edit" | "view") {
-    setOpenViewDialog(false);
-    if (to === "edit") {
-      setOpenEditDialog(true);
-    } else {
-      setOpenEditDialog(true);
-    }
-  }
-
-  function handleViewDialogOpenChange(open: boolean, swapTo?: string) {
-    setOpenViewDialog(open);
-    if (swapTo === "edit") {
-      setOpenEditDialog(true);
-    }
-    if (open == false) {
-      setMenuKey((prev) => prev + 1);
-    }
-  }
-
-  function handleDeleteExamFromDialog() {
-    setOpenViewDialog(false);
-    handleDeleteExam();
-  }
-
   return (
     <>
       <hr className="h-px w-full bg-gray-400  border-0" />
 
-      <ContextMenu key={menuKey}>
+      <ContextMenu>
         <ContextMenuTrigger>
-          <div className="h-16 flex flex-row w-full">
-            <div
-              className="w-1 h-full"
-              style={{ backgroundColor: exam.course.color }}
-            ></div>
-            <div className="p-2 flex justify-between w-full hover:bg-gray-100 dark:hover:bg-zinc-800">
-              <div>
-                <h4 className="text-md font-medium text-off-black">
-                  {exam.title}
-                </h4>
-                <h5 className="text-sm text-gray-500 dark:text-gray-400">
-                  {exam.course.title}
-                </h5>
-              </div>
-              <div>
-                <h5 className="text-sm text-gray text-off-black">
-                  {format(utcToZonedTime(exam.examDate, "Etc/UTC"), "MMM d")}
-                </h5>
-              </div>
-            </div>
-          </div>
-        </ContextMenuTrigger>
-
-        <ContextMenuContent hidden={openEditDialog}>
-          <ContextMenuItem onSelect={handleDeleteExam}>Delete</ContextMenuItem>
-          {/*Edit Button*/}
-          <Dialog open={openEditDialog} onOpenChange={handleDialogOpenChange}>
-            <DialogTrigger asChild>
-              <ContextMenuItem onSelect={(e) => e.preventDefault()}>
-                Edit
-              </ContextMenuItem>
-            </DialogTrigger>
-            <EditExamDialog
-              exam={exam}
-              setOpen={setOpenEditDialog}
-              handleDialogOpenChangeFn={handleDialogOpenChange}
-            />
-          </Dialog>
-          {/* View Button */}
           <Dialog
             open={openViewDialog}
-            onOpenChange={handleViewDialogOpenChange}
+            onOpenChange={(open) => setOpenViewDialog(open)}
           >
             <DialogTrigger asChild>
-              <ContextMenuItem onSelect={(e) => e.preventDefault()}>
-                View
-              </ContextMenuItem>
+              <div className="h-16 flex flex-row w-full">
+                <div
+                  className="w-1 h-full"
+                  style={{ backgroundColor: exam.course.color }}
+                ></div>
+                <div className="p-2 flex justify-between w-full hover:bg-gray-100 dark:hover:bg-zinc-800">
+                  <div>
+                    <h4 className="text-md font-medium text-off-black">
+                      {exam.title}
+                    </h4>
+                    <h5 className="text-sm text-gray-500 dark:text-gray-400">
+                      {exam.course.title}
+                    </h5>
+                  </div>
+                  <div>
+                    <h5 className="text-sm text-gray text-off-black">
+                      {format(
+                        utcToZonedTime(exam.examDate, "Etc/UTC"),
+                        "MMM d",
+                      )}
+                    </h5>
+                  </div>
+                </div>
+              </div>
             </DialogTrigger>
             <ViewExamDialog
-              exam={exam}
-              swapDialogFn={() => swapDialog("edit")}
-              handleDeleteExam={handleDeleteExamFromDialog}
+              examID={exam.id}
+              closeDialog={() => setOpenViewDialog(false)}
             />
           </Dialog>
+        </ContextMenuTrigger>
+
+        <ContextMenuContent>
+          <ContextMenuItem onSelect={handleDeleteExam}>Delete</ContextMenuItem>
         </ContextMenuContent>
       </ContextMenu>
     </>

--- a/components/dialogs/ErrorDialogContent.tsx
+++ b/components/dialogs/ErrorDialogContent.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import { DialogContent, DialogHeader, DialogTitle } from "../ui/dialog";
+
+interface ErrorDialogContentProps {
+  title: string;
+  type: "assignment" | "exam";
+}
+
+export default function ErrorDialogContent({
+  title,
+  type,
+}: ErrorDialogContentProps) {
+  return (
+    <DialogContent>
+      <DialogHeader>
+        <DialogTitle>{title}</DialogTitle>
+      </DialogHeader>
+      <p className="text-lg font-medium text-center">
+        {type === "assignment"
+          ? "An error occurred while fetching the assignment."
+          : "An error occurred while fetching the exam."}
+      </p>
+    </DialogContent>
+  );
+}

--- a/components/dialogs/LoadingDialogContent.tsx
+++ b/components/dialogs/LoadingDialogContent.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+import { DialogContent, DialogHeader, DialogTitle } from "../ui/dialog";
+import LoadingListShorter from "../Loading/LoadingListShorter";
+
+interface LoadingDialogContentProps {
+  title: string;
+}
+
+export default function LoadingDialog({ title }: LoadingDialogContentProps) {
+  return (
+    <DialogContent>
+      <DialogHeader>
+        <DialogTitle>{title}</DialogTitle>
+      </DialogHeader>
+      <LoadingListShorter />
+    </DialogContent>
+  );
+}

--- a/components/dialogs/assignments/EditAssignmentDialog.tsx
+++ b/components/dialogs/assignments/EditAssignmentDialog.tsx
@@ -52,9 +52,7 @@ const EditAssignmentDialog: React.FC<EditAssignmentDialogProps> = ({
   const { assignment, assignmentError, assignmentLoading } =
     useAssignment(assignmentID);
 
-  if (!assignment) return <></>;
-
-  const { form, courses, onSubmit } = useEditAssignmentForm(assignment);
+  const { form, courses, onSubmit } = useEditAssignmentForm(assignmentID);
   if (!assignment && assignmentLoading)
     return <LoadingDialogContent title="Edit Assignment" />;
 

--- a/components/dialogs/assignments/EditAssignmentDialog.tsx
+++ b/components/dialogs/assignments/EditAssignmentDialog.tsx
@@ -34,19 +34,33 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/utils";
 import { useEditAssignmentForm } from "@/app/_hooks/forms/useEditAssignmentForm";
+import { useState } from "react";
+import useAssignment from "./useAssignment";
+import LoadingListShorter from "@/components/Loading/LoadingListShorter";
 
 interface EditAssignmentDialogProps {
-  assignment: Assignment;
+  assignmentID: string;
+  closeDialog: () => void;
 }
 
 const EditAssignmentDialog: React.FC<EditAssignmentDialogProps> = ({
-  assignment,
+  assignmentID,
+  closeDialog,
 }) => {
-  const { form, courses, onSubmit } = useEditAssignmentForm(
-    assignment,
-    () => {},
-  );
+  const { assignment, assignmentError, assignmentLoading } =
+    useAssignment(assignmentID);
 
+  if (assignmentLoading || !assignment)
+    return (
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Edit Assignment</DialogTitle>
+        </DialogHeader>
+        <LoadingListShorter />
+      </DialogContent>
+    );
+
+  const { form, courses, onSubmit } = useEditAssignmentForm(assignment);
   return (
     <DialogContent>
       <DialogHeader>
@@ -168,7 +182,11 @@ const EditAssignmentDialog: React.FC<EditAssignmentDialogProps> = ({
             />
           </div>
           <div className="flex justify-center">
-            <button type="submit" className="btn mt-4">
+            <button
+              type="submit"
+              className="btn mt-4"
+              onClick={() => closeDialog()}
+            >
               Edit Assignment
             </button>
           </div>

--- a/components/dialogs/assignments/EditAssignmentDialog.tsx
+++ b/components/dialogs/assignments/EditAssignmentDialog.tsx
@@ -52,15 +52,15 @@ const EditAssignmentDialog: React.FC<EditAssignmentDialogProps> = ({
   const { assignment, assignmentError, assignmentLoading } =
     useAssignment(assignmentID);
 
+  if (!assignment) return <></>;
+
+  const { form, courses, onSubmit } = useEditAssignmentForm(assignment);
   if (!assignment && assignmentLoading)
     return <LoadingDialogContent title="Edit Assignment" />;
 
   if (!assignment && assignmentError)
     return <ErrorDialogContent title="Edit Assignment" type="assignment" />;
 
-  if (!assignment) return null;
-
-  const { form, courses, onSubmit } = useEditAssignmentForm(assignment);
   return (
     <DialogContent>
       <DialogHeader>

--- a/components/dialogs/assignments/EditAssignmentDialog.tsx
+++ b/components/dialogs/assignments/EditAssignmentDialog.tsx
@@ -37,19 +37,15 @@ import { useEditAssignmentForm } from "@/app/_hooks/forms/useEditAssignmentForm"
 
 interface EditAssignmentDialogProps {
   assignment: Assignment;
-  setOpen: (open: boolean) => void;
-  handleDialogOpenChangeFn: (open: boolean) => void;
 }
 
 const EditAssignmentDialog: React.FC<EditAssignmentDialogProps> = ({
   assignment,
-  setOpen,
-  handleDialogOpenChangeFn,
 }) => {
-  const { form, courses, onSubmit } = useEditAssignmentForm(assignment, () => {
-    setOpen(false);
-    handleDialogOpenChangeFn(false);
-  });
+  const { form, courses, onSubmit } = useEditAssignmentForm(
+    assignment,
+    () => {},
+  );
 
   return (
     <DialogContent>

--- a/components/dialogs/assignments/EditAssignmentDialog.tsx
+++ b/components/dialogs/assignments/EditAssignmentDialog.tsx
@@ -37,6 +37,8 @@ import { useEditAssignmentForm } from "@/app/_hooks/forms/useEditAssignmentForm"
 import { useState } from "react";
 import useAssignment from "./useAssignment";
 import LoadingListShorter from "@/components/Loading/LoadingListShorter";
+import LoadingDialogContent from "../LoadingDialogContent";
+import ErrorDialogContent from "../ErrorDialogContent";
 
 interface EditAssignmentDialogProps {
   assignmentID: string;
@@ -50,15 +52,13 @@ const EditAssignmentDialog: React.FC<EditAssignmentDialogProps> = ({
   const { assignment, assignmentError, assignmentLoading } =
     useAssignment(assignmentID);
 
-  if (assignmentLoading || !assignment)
-    return (
-      <DialogContent>
-        <DialogHeader>
-          <DialogTitle>Edit Assignment</DialogTitle>
-        </DialogHeader>
-        <LoadingListShorter />
-      </DialogContent>
-    );
+  if (!assignment && assignmentLoading)
+    return <LoadingDialogContent title="Edit Assignment" />;
+
+  if (!assignment && assignmentError)
+    return <ErrorDialogContent title="Edit Assignment" type="assignment" />;
+
+  if (!assignment) return null;
 
   const { form, courses, onSubmit } = useEditAssignmentForm(assignment);
   return (

--- a/components/dialogs/assignments/ViewAssignmentDialog.tsx
+++ b/components/dialogs/assignments/ViewAssignmentDialog.tsx
@@ -41,23 +41,13 @@ const ViewAssignmentDialog: React.FC<ViewAssignmentDialogProps> = ({
   const { assignment, assignmentError, assignmentLoading } =
     useAssignment(assignmentID);
 
-  if (assignmentLoading || !assignment) {
-    return (
-      <DialogContent>
-        <DialogHeader>
-          <DialogTitle>View Assignment</DialogTitle>
-        </DialogHeader>
-        <LoadingListShorter />
-      </DialogContent>
-    );
-  }
-
   if (!assignment && assignmentLoading) {
     return <LoadingDialogContent title="View Assignment" />;
   }
   if (!assignment && assignmentError) {
     return <ErrorDialogContent title="View Assignment" type="assignment" />;
   }
+  if (!assignment) return null;
 
   function handleCompleteAssignment() {
     deleteAssignmentMutation.mutate(assignmentID);

--- a/components/dialogs/assignments/ViewAssignmentDialog.tsx
+++ b/components/dialogs/assignments/ViewAssignmentDialog.tsx
@@ -1,31 +1,26 @@
 "use client";
 import { Checkbox } from "@/components/ui/checkbox";
 import {
+  Dialog,
   DialogContent,
   DialogHeader,
   DialogTitle,
+  DialogTrigger,
 } from "@/components/ui/dialog";
 import { Label } from "@/components/ui/label";
 import { format } from "date-fns";
 import utcToZonedTime from "date-fns-tz/utcToZonedTime";
+import EditAssignmentDialog from "./EditAssignmentDialog";
 
 interface ViewAssignmentDialogProps {
   assignment: Assignment;
-  swapDialogFn: (to: "edit" | "view") => void;
-  handleDeleteAssignment: () => void;
 }
 
 const ViewAssignmentDialog: React.FC<ViewAssignmentDialogProps> = ({
   assignment,
-  swapDialogFn,
-  handleDeleteAssignment,
 }) => {
   const labelStyle = "font-light";
   const pStyle = "text-lg font-medium";
-
-  function handleEditAssignment() {
-    swapDialogFn("edit");
-  }
 
   return (
     <DialogContent className="lg:max-w-[500px]">
@@ -58,12 +53,13 @@ const ViewAssignmentDialog: React.FC<ViewAssignmentDialogProps> = ({
         </div>
       </div>
       <div className="flex justify-center">
-        <button className="btn mt-4" onClick={handleEditAssignment}>
-          Edit
-        </button>
-        <button className="btn mt-4 ml-4" onClick={handleDeleteAssignment}>
-          Complete
-        </button>
+        <Dialog>
+          <DialogTrigger asChild>
+            <button className="btn mt-4">Edit</button>
+          </DialogTrigger>
+          <EditAssignmentDialog assignment={assignment} />
+        </Dialog>
+        <button className="btn mt-4 ml-4">Complete</button>
       </div>
     </DialogContent>
   );

--- a/components/dialogs/assignments/ViewAssignmentDialog.tsx
+++ b/components/dialogs/assignments/ViewAssignmentDialog.tsx
@@ -16,6 +16,8 @@ import { deleteAssignment, getAssignment } from "@/server/apis/assignments";
 import LoadingListShorter from "@/components/Loading/LoadingListShorter";
 import useAssignment from "./useAssignment";
 import { useState } from "react";
+import LoadingDialogContent from "../LoadingDialogContent";
+import ErrorDialogContent from "../ErrorDialogContent";
 
 interface ViewAssignmentDialogProps {
   assignmentID: string;
@@ -48,6 +50,13 @@ const ViewAssignmentDialog: React.FC<ViewAssignmentDialogProps> = ({
         <LoadingListShorter />
       </DialogContent>
     );
+  }
+
+  if (!assignment && assignmentLoading) {
+    return <LoadingDialogContent title="View Assignment" />;
+  }
+  if (!assignment && assignmentError) {
+    return <ErrorDialogContent title="View Assignment" type="assignment" />;
   }
 
   function handleCompleteAssignment() {

--- a/components/dialogs/assignments/useAssignment.tsx
+++ b/components/dialogs/assignments/useAssignment.tsx
@@ -1,0 +1,15 @@
+import { getAssignment } from "@/server/apis/assignments";
+import { useQuery } from "@tanstack/react-query";
+import React from "react";
+
+export default function useAssignment(assignmentID: string) {
+  const {
+    data: assignment,
+    error: assignmentError,
+    isLoading: assignmentLoading,
+  } = useQuery<Assignment>({
+    queryKey: ["assignment", assignmentID],
+    queryFn: () => getAssignment(assignmentID),
+  });
+  return { assignment, assignmentError, assignmentLoading };
+}

--- a/components/dialogs/exams/EditExamDialog.tsx
+++ b/components/dialogs/exams/EditExamDialog.tsx
@@ -33,25 +33,29 @@ import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/utils";
 import { updateExam } from "@/server/actions";
 import { useEditExamForm } from "@/app/_hooks/forms/useEditExamForm";
+import useExam from "./useExam";
+import LoadingDialogContent from "../LoadingDialogContent";
+import ErrorDialogContent from "../ErrorDialogContent";
 
 interface EditExamDialogProps {
-  exam: Exam;
-  setOpen: (open: boolean) => void;
-  handleDialogOpenChangeFn: (open: boolean) => void;
+  examID: string;
+  closeDialog: () => void;
 }
 
 const EditExamDialog: React.FC<EditExamDialogProps> = ({
-  exam,
-  setOpen,
-  handleDialogOpenChangeFn,
+  examID,
+  closeDialog,
 }) => {
-  const { form, courses, onSubmit, updateExamMutation } = useEditExamForm(
-    exam,
-    () => {
-      setOpen(false);
-      handleDialogOpenChangeFn(false);
-    },
-  );
+  const { exam, examError, examLoading } = useExam(examID);
+
+  if (!exam && examLoading) return <LoadingDialogContent title="Edit Exam" />;
+
+  if (!exam && examError)
+    return <ErrorDialogContent title="Edit Exam" type="exam" />;
+
+  if (!exam) return null;
+
+  const { form, courses, onSubmit } = useEditExamForm(exam);
 
   return (
     <DialogContent className="w-1/2">
@@ -154,7 +158,11 @@ const EditExamDialog: React.FC<EditExamDialogProps> = ({
             />
           </div>
           <div className="flex justify-center">
-            <button type="submit" className="btn mt-4">
+            <button
+              type="submit"
+              className="btn mt-4"
+              onClick={() => closeDialog()}
+            >
               Edit Exam
             </button>
           </div>

--- a/components/dialogs/exams/EditExamDialog.tsx
+++ b/components/dialogs/exams/EditExamDialog.tsx
@@ -48,14 +48,12 @@ const EditExamDialog: React.FC<EditExamDialogProps> = ({
 }) => {
   const { exam, examError, examLoading } = useExam(examID);
 
+  const { form, courses, onSubmit } = useEditExamForm(examID);
+
   if (!exam && examLoading) return <LoadingDialogContent title="Edit Exam" />;
 
   if (!exam && examError)
     return <ErrorDialogContent title="Edit Exam" type="exam" />;
-
-  if (!exam) return null;
-
-  const { form, courses, onSubmit } = useEditExamForm(exam);
 
   return (
     <DialogContent>

--- a/components/dialogs/exams/EditExamDialog.tsx
+++ b/components/dialogs/exams/EditExamDialog.tsx
@@ -58,7 +58,7 @@ const EditExamDialog: React.FC<EditExamDialogProps> = ({
   const { form, courses, onSubmit } = useEditExamForm(exam);
 
   return (
-    <DialogContent className="w-1/2">
+    <DialogContent>
       <DialogHeader>
         <DialogTitle>Edit Exam</DialogTitle>
       </DialogHeader>

--- a/components/dialogs/exams/ViewExamDialog.tsx
+++ b/components/dialogs/exams/ViewExamDialog.tsx
@@ -6,28 +6,37 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Label } from "@/components/ui/label";
+import { deleteExam } from "@/server/actions";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { format } from "date-fns";
 import utcToZonedTime from "date-fns-tz/utcToZonedTime";
 
 interface ViewExamDialogProps {
-  exam: Exam;
-  swapDialogFn: (to: "edit" | "view") => void;
-  handleDeleteExam: () => void;
+  examID: string;
+  closeDialog: () => void;
 }
 
-import React from "react";
+import React, { useState } from "react";
+import useExam from "./useExam";
 
 export default function ViewExamDialog({
-  exam,
-  swapDialogFn,
-  handleDeleteExam,
+  examID,
+  closeDialog,
 }: ViewExamDialogProps) {
   const labelStyle = "font-light";
   const pStyle = "text-lg font-medium";
 
-  function handleEditExam() {
-    swapDialogFn("edit");
-  }
+  const [openEditDialog, setOpenEditDialog] = useState(false);
+
+  const queryClient = useQueryClient();
+  const deleteExamMutation = useMutation({
+    mutationFn: deleteExam,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["exams"] });
+    },
+  });
+
+  const { exam, examError, examLoading } = useExam(examID);
 
   return (
     <DialogContent className="lg:max-w-[500px]">

--- a/components/dialogs/exams/ViewExamDialog.tsx
+++ b/components/dialogs/exams/ViewExamDialog.tsx
@@ -1,9 +1,11 @@
 "use client";
 import { Checkbox } from "@/components/ui/checkbox";
 import {
+  Dialog,
   DialogContent,
   DialogHeader,
   DialogTitle,
+  DialogTrigger,
 } from "@/components/ui/dialog";
 import { Label } from "@/components/ui/label";
 import { deleteExam } from "@/server/actions";
@@ -18,14 +20,14 @@ interface ViewExamDialogProps {
 
 import React, { useState } from "react";
 import useExam from "./useExam";
+import LoadingDialogContent from "../LoadingDialogContent";
+import ErrorDialogContent from "../ErrorDialogContent";
+import EditExamDialog from "./EditExamDialog";
 
 export default function ViewExamDialog({
   examID,
   closeDialog,
 }: ViewExamDialogProps) {
-  const labelStyle = "font-light";
-  const pStyle = "text-lg font-medium";
-
   const [openEditDialog, setOpenEditDialog] = useState(false);
 
   const queryClient = useQueryClient();
@@ -38,6 +40,23 @@ export default function ViewExamDialog({
 
   const { exam, examError, examLoading } = useExam(examID);
 
+  if (!exam && examLoading) {
+    return <LoadingDialogContent title="View Exam" />;
+  }
+
+  if (!exam && examError) {
+    return <ErrorDialogContent title="View Exam" type="exam" />;
+  }
+
+  if (!exam) return null;
+
+  function handleDeleteExam() {
+    deleteExamMutation.mutate(examID);
+    closeDialog();
+  }
+
+  const labelStyle = "font-light";
+  const pStyle = "text-lg font-medium";
   return (
     <DialogContent className="lg:max-w-[500px]">
       <DialogHeader>
@@ -62,11 +81,20 @@ export default function ViewExamDialog({
         </div>
       </div>
       <div className="flex justify-center">
-        <button className="btn mt-4" onClick={handleEditExam}>
-          Edit
-        </button>
+        <Dialog
+          open={openEditDialog}
+          onOpenChange={(open) => setOpenEditDialog(open)}
+        >
+          <DialogTrigger asChild>
+            <button className="btn mt-4">Edit</button>
+          </DialogTrigger>
+          <EditExamDialog
+            examID={examID}
+            closeDialog={() => setOpenEditDialog(false)}
+          />
+        </Dialog>
         <button className="btn mt-4 ml-4" onClick={handleDeleteExam}>
-          Complete
+          Delete
         </button>
       </div>
     </DialogContent>

--- a/components/dialogs/exams/ViewExamDialog.tsx
+++ b/components/dialogs/exams/ViewExamDialog.tsx
@@ -24,9 +24,11 @@ export default function ViewExamDialog({
 }: ViewExamDialogProps) {
   const labelStyle = "font-light";
   const pStyle = "text-lg font-medium";
+
   function handleEditExam() {
     swapDialogFn("edit");
   }
+
   return (
     <DialogContent className="lg:max-w-[500px]">
       <DialogHeader>

--- a/components/dialogs/exams/useExam.tsx
+++ b/components/dialogs/exams/useExam.tsx
@@ -1,0 +1,15 @@
+import { getExam } from "@/server/apis/exams";
+import { useQuery } from "@tanstack/react-query";
+
+export default function useExam(examID: string) {
+  const {
+    data: exam,
+    error: examError,
+    isLoading: examLoading,
+  } = useQuery<Exam>({
+    queryKey: ["exam", examID],
+    queryFn: () => getExam(examID),
+  });
+
+  return { exam, examError, examLoading };
+}

--- a/server/actions.ts
+++ b/server/actions.ts
@@ -287,7 +287,7 @@ export async function getOverdueAssignments() {
   return data;
 }
 
-export async function deleteExam(id: number) {
+export async function deleteExam(id: string) {
   const supabase = await createSupabaseServerClient();
   const { data, error } = await supabase.from("exams").delete().eq("id", id);
 

--- a/server/actions.ts
+++ b/server/actions.ts
@@ -206,7 +206,7 @@ interface Assignments {
 }
 export async function getCategorizedAssignments() {
   const supabase = await createSupabaseServerClient();
-  ("use server");
+  "use server";
   let assignments: Assignments = {
     priority: [],
     overdue: [],
@@ -297,7 +297,7 @@ export async function deleteExam(id: number) {
   }
 }
 
-export async function deleteAssignment(id: number) {
+export async function deleteAssignment(id: string) {
   const supabase = await createSupabaseServerClient();
   const { error } = await supabase.from("assignments").delete().eq("id", id);
 

--- a/server/apis/assignments.ts
+++ b/server/apis/assignments.ts
@@ -252,7 +252,7 @@ export async function fetchAssignmentsInRange(startDate: Date, endDate: Date) {
   return data;
 }
 
-export async function getAssignment(id: number): Promise<Assignment> {
+export async function getAssignment(id: string): Promise<Assignment> {
   const { data, error } = await supabase
     .from("assignments")
     .select(
@@ -272,7 +272,7 @@ export async function getAssignment(id: number): Promise<Assignment> {
   return data[0];
 }
 
-export async function deleteAssignment(id: number) {
+export async function deleteAssignment(id: string) {
   const { data, error } = await supabase
     .from("assignments")
     .delete()

--- a/server/apis/exams.ts
+++ b/server/apis/exams.ts
@@ -19,7 +19,7 @@ export async function getExams() {
   return exams || [];
 }
 
-export async function getExam(id: number): Promise<Exam> {
+export async function getExam(id: string): Promise<Exam> {
   const supabase = createSupabaseFrontendClient();
   const { data, error } = await supabase
     .from("exams")


### PR DESCRIPTION
Right clicking an exam or assignment used to make a context menu appear where the user could jump edit, view, or delete an assignment in one click. Within the edit or view dialogs, one could jump between the two, and it would "swap" the dialogs, making one go away, and new one appear. This was surprisingly difficult to implement, but it worked. I wanted to make it so that if on mobile, you just "left clicked" the task, it would take you the view "event" dialog, but this proved even harder to implement given the complicated "swap dialog" logic.

Right click is still supported, but only for deleting events. Left clicking an event takes you to the view event screen, where you can either edit or delete the event. This was a lot easier to do and is more mobile friendly now.